### PR TITLE
Explicitly link wiki.emfcamp, code format

### DIFF
--- a/wiki.md
+++ b/wiki.md
@@ -1,13 +1,13 @@
 # Wiki (semantic-mediawiki)
-The EMF Wiki (https://wiki.emfcamp.org/wiki) runs MediaWiki (which has its [own API](https://www.mediawiki.org/wiki/API:Main_page)), with the [Semantic MediaWiki](https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki) extension.
+The EMF Wiki ([https://wiki.emfcamp.org/wiki](https://wiki.emfcamp.org/wiki)) runs MediaWiki (which has its [own API](https://www.mediawiki.org/wiki/API:Main_page)), with the [Semantic MediaWiki](https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki) extension.
 
 Semantic MediaWiki's API allows for structured data queries, and is [well documented](https://www.semantic-mediawiki.org/wiki/Help:API).
 
 ## Endpoint
- - https://wiki.emfcamp.org/w/api.php
+ - `https://wiki.emfcamp.org/w/api.php`
 
 ## Method
- - POST
+ - `POST`
 
 ## Example
  - `/w/api.php?action=browsebysubject&format=json&subject=User%3ATheresNoTime`


### PR DESCRIPTION
Didn't realise `https://wiki.emfcamp.org/wiki` wouldn't auto-link, so have explicitly done so.

Wrapped other links/API doc things in `code tags`