### PR TITLE
Fix transcription URL

### DIFF
--- a/transcription.md
+++ b/transcription.md
@@ -1,7 +1,7 @@
 # Stage Text
 We have an API that provides a feed of the live transcription from each of the 3 stages.
 
-You can fetch a text file of the talk so far at `https://stagetext.emf.app/history/[stage]`,
+You can fetch a text file of the talk so far at `https://stagetext.emfcamp.app/history/[stage]`,
 or you can connect a websocket to `wss://stagetext.emfcamp.app/socket/[stage]` to get a live feed.
 
 Replace [stage] with `a` `b` or `c` depending on the stage you are interested in.


### PR DESCRIPTION
One of the transcription endpoints is specified as "emf.app", which
should be "emfcamp.app"