### PR TITLE
Fix wiki URL

### DIFF
--- a/wiki.md
+++ b/wiki.md
@@ -1,5 +1,5 @@
 # Wiki (semantic-mediawiki)
-The EMF Wiki ([https://wiki.emfcamp.org/wiki](https://wiki.emfcamp.org/wiki)) runs MediaWiki (which has its [own API](https://www.mediawiki.org/wiki/API:Main_page)), with the [Semantic MediaWiki](https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki) extension.
+The EMF Wiki ([https://wiki.emfcamp.org/wiki/](https://wiki.emfcamp.org/wiki/)) runs MediaWiki (which has its [own API](https://www.mediawiki.org/wiki/API:Main_page)), with the [Semantic MediaWiki](https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki) extension.
 
 Semantic MediaWiki's API allows for structured data queries, and is [well documented](https://www.semantic-mediawiki.org/wiki/Help:API).
 


### PR DESCRIPTION
Weirdly enough mediawiki seems to care about whether or not you put a
trailing / at the end of the URL.  "/wiki" is a 404 while "/wiki/" is
the wiki homepage.