### PR TITLE
Make the attendee-run API links into actual links instead of plain text

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,5 +25,5 @@ Official APIs:
 
 Attendee-run APIs:
 --
-* Duck fact of the day API: https://03vpefsitf.execute-api.eu-west-1.amazonaws.com/prod/
-* Giant Rubik's Cube solve data API: https://github.com/danieljabailey/giant_led_cube/blob/main/api.md
+* Duck fact of the day API: [https://03vpefsitf.execute-api.eu-west-1.amazonaws.com/prod/](https://03vpefsitf.execute-api.eu-west-1.amazonaws.com/prod/)
+* Giant Rubik's Cube solve data API: [https://github.com/danieljabailey/giant_led_cube/blob/main/api.md](https://github.com/danieljabailey/giant_led_cube/blob/main/api.md)


### PR DESCRIPTION
Turns out that the links only render as links in github's markdown renderer, not on the actual site.

I _think_ this syntax should fix that, it is the normal markdown link syntax and looks mostly like the other links so should be fine.