### PR TITLE
Update attendee-run.md to fix links

### DIFF
--- a/content/attendee-run.md
+++ b/content/attendee-run.md
@@ -5,5 +5,6 @@ description: Attendee-run APIs that don't get a mention elsewhere
 
 Here are some links to attendee-run APIs:
 
-* Duck fact of the day API: [https://03vpefsitf.execute-api.eu-west-1.amazonaws.com/prod/](https://03vpefsitf.execute-api.eu-west-1.amazonaws.com/prod/)
-* Giant Rubik's Cube solve data API: [https://github.com/danieljabailey/giant_led_cube/blob/main/api.md](https://github.com/danieljabailey/giant_led_cube/blob/main/api.md)
+* Duck fact of the day API: [Duck Fact of the day](https://03vpefsitf.execute-api.eu-west-1.amazonaws.com/prod/)
+* Giant Rubik's Cube solve data API: [Giant LED Rubik's cube](https://github.com/lexbailey/giant_led_cube)
+


### PR DESCRIPTION
- Fix link to the Giant LED cube repo
- Tidy up the Duck Facts API link