### PR TITLE
Adds details of my schedule API shim to attendee run API list

### DIFF
--- a/content/attendee-run.md
+++ b/content/attendee-run.md
@@ -6,4 +6,5 @@ description: Attendee-run APIs that don't get a mention elsewhere
 Here are some links to attendee-run APIs:
 
 * Duck fact of the day API: [https://03vpefsitf.execute-api.eu-west-1.amazonaws.com/prod/](https://03vpefsitf.execute-api.eu-west-1.amazonaws.com/prod/)
+* Enhanced schedule API: [details](https://github.com/DanNixon/emfcamp-schedule-api/tree/main/adapter), 2024: [https://schedule.emfcamp.dan-nixon.com/](https://schedule.emfcamp.dan-nixon.com/), 2022: [https://2022.schedule.emfcamp.dan-nixon.com/](https://2022.schedule.emfcamp.dan-nixon.com/)
 * Giant Rubik's Cube solve data API: [https://github.com/danieljabailey/giant_led_cube/blob/main/api.md](https://github.com/danieljabailey/giant_led_cube/blob/main/api.md)


### PR DESCRIPTION
This has so far been a useful tool for myself and others in developing [cool](https://github.com/IainYa/Badger-2040-W-emfcamp-Now-Next) [stuff](https://github.com/DanNixon/emfcamp-dapnet-schedule-announcer) (mainly the ability to fake being at the event).