### PR TITLE
Add a docs link to my MQTT schedule announcements

### DIFF
--- a/content/attendee-run.md
+++ b/content/attendee-run.md
@@ -8,3 +8,4 @@ Here are some links to attendee-run APIs:
 * Duck fact of the day API: [https://03vpefsitf.execute-api.eu-west-1.amazonaws.com/prod/](https://03vpefsitf.execute-api.eu-west-1.amazonaws.com/prod/)
 * Enhanced schedule API: [details](https://github.com/DanNixon/emfcamp-schedule-api/tree/main/adapter), 2024: [https://schedule.emfcamp.dan-nixon.com/](https://schedule.emfcamp.dan-nixon.com/), 2022: [https://2022.schedule.emfcamp.dan-nixon.com/](https://2022.schedule.emfcamp.dan-nixon.com/)
 * Giant Rubik's Cube solve data API: [https://github.com/danieljabailey/giant_led_cube/blob/main/api.md](https://github.com/danieljabailey/giant_led_cube/blob/main/api.md)
+* [MQTT schedule announcements](https://github.com/DanNixon/emfcamp-2024/blob/main/cloud-apps/schedule-mqtt-announcer/README.md)


### PR DESCRIPTION
Can be used as a source for push notifications, LED message boards, etc.